### PR TITLE
Fix oculus/vive examples and make sure text component is updated.

### DIFF
--- a/examples/oculus/index.html
+++ b/examples/oculus/index.html
@@ -13,42 +13,42 @@
       <a-cylinder position="1 0.75 -3" radius="0.5" height="1.5" color="#FFC65D"></a-cylinder>
       <a-plane position="0 0 -4" rotation="-90 0 0" width="4" height="4" color="#7BC8A4"></a-plane>
       <a-entity oculus-touch-controls="hand: right">
-        <a-entity id="tooltip_a" tooltip="text: Button A; width: 0.06; height: 0.03; targetPosition: -0.011 0.0 0.058; rotation: -90 0 0; lineHorizontalAlign: right"
+        <a-entity id="tooltip_a" tooltip="text: Button A; width: 0.06; height: 0.03; targetPosition: -0.011 0.0 0.058; rotation: -90 0 0; lineHorizontalAlign: right; src:tooltip.png"
             position="-0.070 0.006 0.053">
         </a-entity>
-        <a-entity id="tooltip_b" tooltip="text: Button B; width: 0.06; height: 0.03; targetPosition: -0.017 -0.008 0.047; rotation: -90 0 0; lineHorizontalAlign: right"
+        <a-entity id="tooltip_b" tooltip="text: Button B; width: 0.06; height: 0.03; targetPosition: -0.017 -0.008 0.047; rotation: -90 0 0; lineHorizontalAlign: right; src:tooltip.png"
             position="-0.065 0.001 0.020">
         </a-entity>
-        <a-entity id="tooltip_mainmenu" tooltip="text: Main menu; width: 0.07; height: 0.03; targetPosition: 0.003 0.0013 0.062; lineVerticalAlign: center; rotation: -90 0 0"
+        <a-entity id="tooltip_mainmenu" tooltip="text: Main menu; width: 0.07; height: 0.03; targetPosition: 0.003 0.0013 0.062; lineVerticalAlign: center; rotation: -90 0 0; src:tooltip.png"
             position="0.074 0.021 0.066">
         </a-entity>
-        <a-entity id="tooltip_thumb" tooltip="text: Thumbstick; width: 0.07; height: 0.03; targetPosition: 0.0014 -0.006 0.046; lineHorizontalAlign: center; lineVerticalAlign: bottom; rotation: -90 0 0"
+        <a-entity id="tooltip_thumb" tooltip="text: Thumbstick; width: 0.07; height: 0.03; targetPosition: 0.0014 -0.006 0.046; lineHorizontalAlign: center; lineVerticalAlign: bottom; rotation: -90 0 0; src:tooltip.png"
             position="-0.012 -0.027 -0.039">
         </a-entity>
-        <a-entity id="tooltip_trigger" tooltip="text: Trigger; width: 0.07; height: 0.03; targetPosition: -0.0062 -0.033 0.048; lineHorizontalAlign: left; rotation: -90 0 0"
+        <a-entity id="tooltip_trigger" tooltip="text: Trigger; width: 0.07; height: 0.03; targetPosition: -0.0062 -0.033 0.048; lineHorizontalAlign: left; rotation: -90 0 0; src:tooltip.png"
             position="0.09 -0.04 0">
         </a-entity>
-        <a-entity id="tooltip_grip" tooltip="text: Grip; width: 0.06; height: 0.03; targetPosition: -0.007 -0.008 0.087; rotation: -90 0 0; lineHorizontalAlign: right"
+        <a-entity id="tooltip_grip" tooltip="text: Grip; width: 0.06; height: 0.03; targetPosition: -0.007 -0.008 0.087; rotation: -90 0 0; lineHorizontalAlign: right; src:tooltip.png"
             position="-0.06 -0.01 0.12">
         </a-entity>
       </a-entity>
       <a-entity oculus-touch-controls="hand: left">
-        <a-entity id="tooltip_x" tooltip="text: Button X; width: 0.06; height: 0.03; targetPosition: 0.011 0.0 0.058; rotation: -90 0 0"
+        <a-entity id="tooltip_x" tooltip="text: Button X; width: 0.06; height: 0.03; targetPosition: 0.011 0.0 0.058; rotation: -90 0 0; src:tooltip.png"
             position="0.070 0.006 0.053">
         </a-entity>
-        <a-entity id="tooltip_y" tooltip="text: Button Y; width: 0.06; height: 0.03; targetPosition: 0.017 -0.008 0.047; rotation: -90 0 0"
+        <a-entity id="tooltip_y" tooltip="text: Button Y; width: 0.06; height: 0.03; targetPosition: 0.017 -0.008 0.047; rotation: -90 0 0; src:tooltip.png"
             position="0.065 0.001 0.020">
         </a-entity>
-        <a-entity id="tooltip_mainmenu" tooltip="text: Main menu; width: 0.07; height: 0.03; targetPosition: -0.003 0.0013 0.062; lineHorizontalAlign: right; lineVerticalAlign: center; rotation: -90 0 0"
+        <a-entity id="tooltip_mainmenu" tooltip="text: Main menu; width: 0.07; height: 0.03; targetPosition: -0.003 0.0013 0.062; lineHorizontalAlign: right; lineVerticalAlign: center; rotation: -90 0 0; src:tooltip.png"
             position="-0.074 0.021 0.066">
         </a-entity>
-        <a-entity id="tooltip_thumb" tooltip="text: Thumbstick; width: 0.07; height: 0.03; targetPosition: -0.0014 -0.006 0.046; lineHorizontalAlign: center; lineVerticalAlign: bottom; rotation: -90 0 0"
+        <a-entity id="tooltip_thumb" tooltip="text: Thumbstick; width: 0.07; height: 0.03; targetPosition: -0.0014 -0.006 0.046; lineHorizontalAlign: center; lineVerticalAlign: bottom; rotation: -90 0 0; src:tooltip.png"
             position="0.012 -0.027 -0.039">
         </a-entity>
-        <a-entity id="tooltip_trigger" tooltip="text: Trigger; width: 0.07; height: 0.03; targetPosition: 0.0062 -0.033 0.048; lineHorizontalAlign: right; rotation: -90 0 0"
+        <a-entity id="tooltip_trigger" tooltip="text: Trigger; width: 0.07; height: 0.03; targetPosition: 0.0062 -0.033 0.048; lineHorizontalAlign: right; rotation: -90 0 0; src:tooltip.png"
             position="-0.09 -0.04 0">
         </a-entity>
-        <a-entity id="tooltip_grip" tooltip="text: Grip; width: 0.06; height: 0.03; targetPosition: 0.007 -0.008 0.087; rotation: -90 0 0"
+        <a-entity id="tooltip_grip" tooltip="text: Grip; width: 0.06; height: 0.03; targetPosition: 0.007 -0.008 0.087; rotation: -90 0 0; src:tooltip.png"
             position="0.06 -0.01 0.12">
         </a-entity>
       </a-entity>

--- a/examples/vive/index.html
+++ b/examples/vive/index.html
@@ -12,19 +12,19 @@
       <a-plane position="0 0 -4" rotation="-90 0 0" width="4" height="4" color="#7BC8A4"></a-plane>
       <a-sky color="#333"></a-sky>
       <a-entity vive-controls>
-        <a-entity id="tooltip_touchpad" tooltip="text: Brush size\n(slide up/down); width: 0.1; height: 0.04; targetPosition: -0.1 0.001 -0.02"
+        <a-entity id="tooltip_touchpad" tooltip="text: Brush size\n(slide up/down); width: 0.1; height: 0.04; targetPosition: -0.1 0.001 -0.02; src: tooltip.png"
                   position="0.1 0.025 0.048"
                   rotation="-90 0 0">
         </a-entity>
-        <a-entity id="tooltip_mainmenu" tooltip="text: Main menu; width: 0.07; height: 0.03; targetPosition: 0 -0.07 -0.008; lineHorizontalAlign: center; lineVerticalAlign: bottom"
+        <a-entity id="tooltip_mainmenu" tooltip="text: Main menu; width: 0.07; height: 0.03; targetPosition: 0 -0.07 -0.008; lineHorizontalAlign: center; lineVerticalAlign: bottom; src: tooltip.png"
                   position="0 0.015 -0.05"
                   rotation="-90 0 0">
         </a-entity>
-        <a-entity id="tooltip_trigger" tooltip="text: Press to paint\n(pressure sensitive); width: 0.11; height: 0.04; targetPosition: 0.115 -0.01 0.02; lineHorizontalAlign: right;"
+        <a-entity id="tooltip_trigger" tooltip="text: Press to paint\n(pressure sensitive); width: 0.11; height: 0.04; targetPosition: 0.115 -0.01 0.02; lineHorizontalAlign: right; src: tooltip.png"
                   position="-0.11 -0.055 0.04"
                   rotation="-90 0 0">
         </a-entity>
-        <a-entity id="tooltip_grip" tooltip="text: Undo; width: 0.06; height: 0.03; targetPosition: -0.08 0.035 -0.01;"
+        <a-entity id="tooltip_grip" tooltip="text: Undo; width: 0.06; height: 0.03; targetPosition: -0.08 0.035 -0.01; src: tooltip.png"
                   position="0.1 -0.005 0.12"
                   rotation="-90 0 0">
         </a-entity>

--- a/index.js
+++ b/index.js
@@ -86,7 +86,7 @@ AFRAME.registerComponent('tooltip', {
        var x = halign[data.lineHorizontalAlign];
 
        this.quad.setAttribute('slice9', {opacity: data.opacity});
-       this.quad.setAttribute('text', {opacity: data.opacity});
+       this.quad.setAttribute('text', {opacity: data.opacity, value: data.text});
 
        // Update geometry
        this.quad.object3D.updateMatrix();


### PR DESCRIPTION
Two minor fixes:
- The tooltips in the oculus and vive examples show up as a plain white textured boxes unless the src image is linked.
- Changing the text via the tooltip didn't change the text in its associated quad, so make sure to do that in `update`

